### PR TITLE
Shorten test data length to make them more readable.

### DIFF
--- a/tests/string/data/accepted.rs
+++ b/tests/string/data/accepted.rs
@@ -83,91 +83,108 @@ pub(crate) const UTF_32_ZERO_ENDED_BIG_EMPTY_IN: &[u8; 4] = b"\x00\x00\x00\x00";
 // ------------------------------------
 
 // ---------- UTF-8: Full buffer valid (str)
-pub(crate) const FIXED_FORCE_ZERO_VALID_STR: &str = "valid test case w zero";
-pub(crate) const FIXED_ALLOW_NO_ZERO_VALID_STR: &str = "valid test case w zero";
-pub(crate) const PREFIX_U8_VALID_STR: &str = "valid test case";
-pub(crate) const PREFIX_U16_VALID_STR: &str = "valid test case";
-pub(crate) const PREFIX_U32_VALID_STR: &str = "valid test case";
-pub(crate) const ZERO_ENDED_VALID_STR: &str = "valid test case";
+pub(crate) const FIXED_FORCE_ZERO_VALID_STR: &str = "zero";
+pub(crate) const FIXED_ALLOW_NO_ZERO_VALID_STR: &str = "zero?";
+pub(crate) const PREFIX_U8_VALID_STR: &str = "valid";
+pub(crate) const PREFIX_U16_VALID_STR: &str = "valid";
+pub(crate) const PREFIX_U32_VALID_STR: &str = "valid";
+pub(crate) const ZERO_ENDED_VALID_STR: &str = "valid";
 
 // ---------- UTF-8: Full buffer valid (little)
 pub(crate) const UTF_8_FIXED_FORCE_ZERO_LITTLE_VALID_IN: &[u8;
-     UTF_8_FIXED_LENGTH_DATA] = b"valid test case w zero\x00";
+     UTF_8_FIXED_LENGTH_DATA] = b"zero\x00";
 pub(crate) const UTF_8_FIXED_ALLOW_NO_ZERO_LITTLE_VALID_IN:
-    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"valid test case w zero\x00";
-pub(crate) const UTF_8_PREFIX_U8_LITTLE_VALID_IN: &[u8; 16] = b"\x0Fvalid test case";
-pub(crate) const UTF_8_PREFIX_U16_LITTLE_VALID_IN: &[u8; 17] =
-    b"\x0F\x00valid test case";
-pub(crate) const UTF_8_PREFIX_U32_LITTLE_VALID_IN: &[u8; 19] =
-    b"\x0F\x00\x00\x00valid test case";
-pub(crate) const UTF_8_ZERO_ENDED_LITTLE_VALID_IN: &[u8; 16] = b"valid test case\x00";
+    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"zero?";
+pub(crate) const UTF_8_PREFIX_U8_LITTLE_VALID_IN: &[u8; 1 + UTF_8_FIXED_LENGTH_DATA] =
+    b"\x05valid";
+pub(crate) const UTF_8_PREFIX_U16_LITTLE_VALID_IN: &[u8; 2 + UTF_8_FIXED_LENGTH_DATA] =
+    b"\x05\x00valid";
+pub(crate) const UTF_8_PREFIX_U32_LITTLE_VALID_IN: &[u8; 4 + UTF_8_FIXED_LENGTH_DATA] =
+    b"\x05\x00\x00\x00valid";
+pub(crate) const UTF_8_ZERO_ENDED_LITTLE_VALID_IN: &[u8; 1 + UTF_8_FIXED_LENGTH_DATA] =
+    b"valid\x00";
 
 // ---------- UTF-8: Full buffer valid (big)
 pub(crate) const UTF_8_FIXED_FORCE_ZERO_BIG_VALID_IN: &[u8; UTF_8_FIXED_LENGTH_DATA] =
-    b"valid test case w zero\x00";
+    b"zero\x00";
 pub(crate) const UTF_8_FIXED_ALLOW_NO_ZERO_BIG_VALID_IN: &[u8;
-     UTF_8_FIXED_LENGTH_DATA] = b"valid test case w zero\x00";
-pub(crate) const UTF_8_PREFIX_U8_BIG_VALID_IN: &[u8; 16] = b"\x0Fvalid test case";
-pub(crate) const UTF_8_PREFIX_U16_BIG_VALID_IN: &[u8; 17] = b"\x00\x0Fvalid test case";
-pub(crate) const UTF_8_PREFIX_U32_BIG_VALID_IN: &[u8; 19] =
-    b"\x00\x00\x00\x0Fvalid test case";
-pub(crate) const UTF_8_ZERO_ENDED_BIG_VALID_IN: &[u8; 16] = b"valid test case\x00";
+     UTF_8_FIXED_LENGTH_DATA] = b"zero?";
+pub(crate) const UTF_8_PREFIX_U8_BIG_VALID_IN: &[u8; 1 + UTF_8_FIXED_LENGTH_DATA] =
+    b"\x05valid";
+pub(crate) const UTF_8_PREFIX_U16_BIG_VALID_IN: &[u8; 2 + UTF_8_FIXED_LENGTH_DATA] =
+    b"\x00\x05valid";
+pub(crate) const UTF_8_PREFIX_U32_BIG_VALID_IN: &[u8; 4 + UTF_8_FIXED_LENGTH_DATA] =
+    b"\x00\x00\x00\x05valid";
+pub(crate) const UTF_8_ZERO_ENDED_BIG_VALID_IN: &[u8; 1 + UTF_8_FIXED_LENGTH_DATA] =
+    b"valid\x00";
 
 // ---------- UTF-16: Full buffer valid (little)
-pub(crate) const UTF_16_FIXED_FORCE_ZERO_LITTLE_VALID_IN: &[u8; UTF_16_FIXED_LENGTH_DATA] = b"v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00 \x00w\x00 \x00z\x00e\x00r\x00o\x00\x00\x00";
-pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_LITTLE_VALID_IN: &[u8; UTF_16_FIXED_LENGTH_DATA] = b"v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00 \x00w\x00 \x00z\x00e\x00r\x00o\x00\x00\x00";
-pub(crate) const UTF_16_PREFIX_U8_LITTLE_VALID_IN: &[u8; 31] =
-    b"\x0Fv\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00";
-pub(crate) const UTF_16_PREFIX_U16_LITTLE_VALID_IN: &[u8; 32] =
-    b"\x0F\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00";
-pub(crate) const UTF_16_PREFIX_U32_LITTLE_VALID_IN: &[u8; 34] =
-    b"\x0F\x00\x00\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00";
-pub(crate) const UTF_16_ZERO_ENDED_LITTLE_VALID_IN: &[u8; 32] =
-    b"v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00\x00\x00";
+pub(crate) const UTF_16_FIXED_FORCE_ZERO_LITTLE_VALID_IN:
+    &[u8; UTF_16_FIXED_LENGTH_DATA] = b"z\x00e\x00r\x00o\x00\x00\x00";
+pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_LITTLE_VALID_IN:
+    &[u8; UTF_16_FIXED_LENGTH_DATA] = b"z\x00e\x00r\x00o\x00?\x00";
+pub(crate) const UTF_16_PREFIX_U8_LITTLE_VALID_IN: &[u8; 1 + UTF_16_FIXED_LENGTH_DATA] =
+    b"\x05v\x00a\x00l\x00i\x00d\x00";
+pub(crate) const UTF_16_PREFIX_U16_LITTLE_VALID_IN: &[u8; 2
+     + UTF_16_FIXED_LENGTH_DATA] = b"\x05\x00v\x00a\x00l\x00i\x00d\x00";
+pub(crate) const UTF_16_PREFIX_U32_LITTLE_VALID_IN: &[u8; 4
+     + UTF_16_FIXED_LENGTH_DATA] = b"\x05\x00\x00\x00v\x00a\x00l\x00i\x00d\x00";
+pub(crate) const UTF_16_ZERO_ENDED_LITTLE_VALID_IN: &[u8; 2
+     + UTF_16_FIXED_LENGTH_DATA] = b"v\x00a\x00l\x00i\x00d\x00\x00\x00";
 
 // ---------- UTF-16: Full buffer valid (big)
-pub(crate) const UTF_16_FIXED_FORCE_ZERO_BIG_VALID_IN: &[u8; UTF_16_FIXED_LENGTH_DATA] = b"\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00 \x00w\x00 \x00z\x00e\x00r\x00o\x00\x00";
-pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_BIG_VALID_IN: &[u8; UTF_16_FIXED_LENGTH_DATA] = b"\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00 \x00w\x00 \x00z\x00e\x00r\x00o\x00\x00";
-pub(crate) const UTF_16_PREFIX_U8_BIG_VALID_IN: &[u8; 31] =
-    b"\x0F\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e";
-pub(crate) const UTF_16_PREFIX_U16_BIG_VALID_IN: &[u8; 32] =
-    b"\x00\x0F\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e";
-pub(crate) const UTF_16_PREFIX_U32_BIG_VALID_IN: &[u8; 34] =
-    b"\x00\x00\x00\x0F\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e";
-pub(crate) const UTF_16_ZERO_ENDED_BIG_VALID_IN: &[u8; 32] =
-    b"\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00\x00";
+pub(crate) const UTF_16_FIXED_FORCE_ZERO_BIG_VALID_IN: &[u8; UTF_16_FIXED_LENGTH_DATA] =
+    b"\x00z\x00e\x00r\x00o\x00\x00";
+pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_BIG_VALID_IN:
+    &[u8; UTF_16_FIXED_LENGTH_DATA] = b"\x00z\x00e\x00r\x00o\x00?";
+pub(crate) const UTF_16_PREFIX_U8_BIG_VALID_IN: &[u8; 1 + UTF_16_FIXED_LENGTH_DATA] =
+    b"\x05\x00v\x00a\x00l\x00i\x00d";
+pub(crate) const UTF_16_PREFIX_U16_BIG_VALID_IN: &[u8; 2 + UTF_16_FIXED_LENGTH_DATA] =
+    b"\x00\x05\x00v\x00a\x00l\x00i\x00d";
+pub(crate) const UTF_16_PREFIX_U32_BIG_VALID_IN: &[u8; 4 + UTF_16_FIXED_LENGTH_DATA] =
+    b"\x00\x00\x00\x05\x00v\x00a\x00l\x00i\x00d";
+pub(crate) const UTF_16_ZERO_ENDED_BIG_VALID_IN: &[u8; 2 + UTF_16_FIXED_LENGTH_DATA] =
+    b"\x00v\x00a\x00l\x00i\x00d\x00\x00";
 
 // ---------- UTF-32: Full buffer valid (little)
-pub(crate) const UTF_32_FIXED_FORCE_ZERO_LITTLE_VALID_IN: &[u8; UTF_32_FIXED_LENGTH_DATA] = b"v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e\x00\x00\x00 \x00\x00\x00w\x00\x00\x00 \x00\x00\x00z\x00\x00\x00e\x00\x00\x00r\x00\x00\x00o\x00\x00\x00\x00\x00\x00\x00";
-pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_LITTLE_VALID_IN: &[u8; UTF_32_FIXED_LENGTH_DATA] = b"v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e\x00\x00\x00 \x00\x00\x00w\x00\x00\x00 \x00\x00\x00z\x00\x00\x00e\x00\x00\x00r\x00\x00\x00o\x00\x00\x00\x00\x00\x00\x00";
-pub(crate) const UTF_32_PREFIX_U8_LITTLE_VALID_IN: &[u8; 61] =
-    b"\x0Fv\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e\x00\x00\x00";
-pub(crate) const UTF_32_PREFIX_U16_LITTLE_VALID_IN: &[u8; 62] =
-    b"\x0F\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e\x00\x00\x00";
-pub(crate) const UTF_32_PREFIX_U32_LITTLE_VALID_IN: &[u8; 64] =
-    b"\x0F\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e\x00\x00\x00";
-pub(crate) const UTF_32_ZERO_ENDED_LITTLE_VALID_IN: &[u8; 64] =
-    b"v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e\x00\x00\x00\x00\x00\x00\x00";
+pub(crate) const UTF_32_FIXED_FORCE_ZERO_LITTLE_VALID_IN:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"z\x00\x00\x00e\x00\x00\x00r\x00\x00\x00o\x00\x00\x00\x00\x00\x00\x00";
+pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_LITTLE_VALID_IN:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"z\x00\x00\x00e\x00\x00\x00r\x00\x00\x00o\x00\x00\x00?\x00\x00\x00";
+pub(crate) const UTF_32_PREFIX_U8_LITTLE_VALID_IN: &[u8; 1 + UTF_32_FIXED_LENGTH_DATA] =
+    b"\x05v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00";
+pub(crate) const UTF_32_PREFIX_U16_LITTLE_VALID_IN: &[u8; 2
+     + UTF_32_FIXED_LENGTH_DATA] =
+    b"\x05\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00";
+pub(crate) const UTF_32_PREFIX_U32_LITTLE_VALID_IN: &[u8; 4
+     + UTF_32_FIXED_LENGTH_DATA] = b"\x05\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00";
+pub(crate) const UTF_32_ZERO_ENDED_LITTLE_VALID_IN: &[u8; 4
+     + UTF_32_FIXED_LENGTH_DATA] = b"v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00";
 
 // ---------- UTF-32: Full buffer valid (big)
-pub(crate) const UTF_32_FIXED_FORCE_ZERO_BIG_VALID_IN: &[u8; UTF_32_FIXED_LENGTH_DATA] = b"\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e\x00\x00\x00 \x00\x00\x00w\x00\x00\x00 \x00\x00\x00z\x00\x00\x00e\x00\x00\x00r\x00\x00\x00o\x00\x00\x00\x00";
-pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_BIG_VALID_IN: &[u8; UTF_32_FIXED_LENGTH_DATA] = b"\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e\x00\x00\x00 \x00\x00\x00w\x00\x00\x00 \x00\x00\x00z\x00\x00\x00e\x00\x00\x00r\x00\x00\x00o\x00\x00\x00\x00";
-pub(crate) const UTF_32_PREFIX_U8_BIG_VALID_IN: &[u8; 61] =
-    b"\x0F\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e";
-pub(crate) const UTF_32_PREFIX_U16_BIG_VALID_IN: &[u8; 62] =
-    b"\x00\x0F\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e";
-pub(crate) const UTF_32_PREFIX_U32_BIG_VALID_IN: &[u8; 64] =
-    b"\x00\x00\x00\x0F\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e";
-pub(crate) const UTF_32_ZERO_ENDED_BIG_VALID_IN: &[u8; 64] =
-    b"\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e\x00\x00\x00\x00";
+pub(crate) const UTF_32_FIXED_FORCE_ZERO_BIG_VALID_IN: &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"\x00\x00\x00z\x00\x00\x00e\x00\x00\x00r\x00\x00\x00o\x00\x00\x00\x00";
+pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_BIG_VALID_IN:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"\x00\x00\x00z\x00\x00\x00e\x00\x00\x00r\x00\x00\x00o\x00\x00\x00?";
+pub(crate) const UTF_32_PREFIX_U8_BIG_VALID_IN: &[u8; 1 + UTF_32_FIXED_LENGTH_DATA] =
+    b"\x05\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d";
+pub(crate) const UTF_32_PREFIX_U16_BIG_VALID_IN: &[u8; 2 + UTF_32_FIXED_LENGTH_DATA] =
+    b"\x00\x05\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d";
+pub(crate) const UTF_32_PREFIX_U32_BIG_VALID_IN: &[u8; 4 + UTF_32_FIXED_LENGTH_DATA] =
+    b"\x00\x00\x00\x05\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d";
+pub(crate) const UTF_32_ZERO_ENDED_BIG_VALID_IN: &[u8; 4 + UTF_32_FIXED_LENGTH_DATA] =
+    b"\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00\x00";
 
 // ------------------------------------
 // ------- Zero in the middle ---------
 // ------------------------------------
 
 // ---------- Zero in the middle (str)
-pub(crate) const FIXED_FORCE_ZERO_ZERO_IN_MIDDLE_STR: &str = "valid test";
-pub(crate) const FIXED_ALLOW_NO_ZERO_ZERO_IN_MIDDLE_STR: &str = "valid test";
+pub(crate) const FIXED_FORCE_ZERO_ZERO_IN_MIDDLE_STR: &str = "va";
+pub(crate) const FIXED_ALLOW_NO_ZERO_ZERO_IN_MIDDLE_STR: &str = "va";
 // pub(crate) const PREFIX_U8_ZERO_IN_MIDDLE_STR -- not allowed
 // pub(crate) const PREFIX_U16_ZERO_IN_MIDDLE_STR -- not allowed
 // pub(crate) const PREFIX_U32_ZERO_IN_MIDDLE_STR -- not allowed
@@ -175,79 +192,90 @@ pub(crate) const FIXED_ALLOW_NO_ZERO_ZERO_IN_MIDDLE_STR: &str = "valid test";
 
 // ---------- UTF-8: Zero in the middle (little-in)
 pub(crate) const UTF_8_FIXED_FORCE_ZERO_LITTLE_ZERO_IN_MIDDLE_IN:
-    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"valid test\x00with garbage";
+    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"va\x00id";
 pub(crate) const UTF_8_FIXED_ALLOW_NO_ZERO_LITTLE_ZERO_IN_MIDDLE_IN:
-    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"valid test\x00with garbage";
+    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"va\x00id";
 
 // ---------- UTF-8: Zero in the middle (little-out)
 pub(crate) const UTF_8_FIXED_FORCE_ZERO_LITTLE_ZERO_IN_MIDDLE_OUT:
-    &[u8; UTF_8_FIXED_LENGTH_DATA] =
-    b"valid test\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"va\x00\x00\x00";
 pub(crate) const UTF_8_FIXED_ALLOW_NO_ZERO_LITTLE_ZERO_IN_MIDDLE_OUT:
-    &[u8; UTF_8_FIXED_LENGTH_DATA] =
-    b"valid test\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"va\x00\x00\x00";
 
 // ---------- UTF-8: Zero in the middle (big-in)
 pub(crate) const UTF_8_FIXED_FORCE_ZERO_BIG_ZERO_IN_MIDDLE_IN:
-    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"valid test\x00with garbage";
+    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"va\x00id";
 pub(crate) const UTF_8_FIXED_ALLOW_NO_ZERO_BIG_ZERO_IN_MIDDLE_IN:
-    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"valid test\x00with garbage";
+    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"va\x00id";
 
 // ---------- UTF-8: Zero in the middle (big-out)
 pub(crate) const UTF_8_FIXED_FORCE_ZERO_BIG_ZERO_IN_MIDDLE_OUT:
-    &[u8; UTF_8_FIXED_LENGTH_DATA] =
-    b"valid test\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"va\x00\x00\x00";
 pub(crate) const UTF_8_FIXED_ALLOW_NO_ZERO_BIG_ZERO_IN_MIDDLE_OUT:
-    &[u8; UTF_8_FIXED_LENGTH_DATA] =
-    b"valid test\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"va\x00\x00\x00";
 
 // ---------- UTF-16: Zero in the middle (little-in)
-pub(crate) const UTF_16_FIXED_FORCE_ZERO_LITTLE_ZERO_IN_MIDDLE_IN: &[u8; UTF_16_FIXED_LENGTH_DATA] = b"v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00\x00\x00w\x00i\x00t\x00h\x00 \x00g\x00a\x00r\x00b\x00a\x00g\x00e\x00";
-pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_LITTLE_ZERO_IN_MIDDLE_IN: &[u8; UTF_16_FIXED_LENGTH_DATA] = b"v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00\x00\x00w\x00i\x00t\x00h\x00 \x00g\x00a\x00r\x00b\x00a\x00g\x00e\x00";
+pub(crate) const UTF_16_FIXED_FORCE_ZERO_LITTLE_ZERO_IN_MIDDLE_IN:
+    &[u8; UTF_16_FIXED_LENGTH_DATA] = b"v\x00a\x00\x00\x00i\x00d\x00";
+pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_LITTLE_ZERO_IN_MIDDLE_IN:
+    &[u8; UTF_16_FIXED_LENGTH_DATA] = b"v\x00a\x00\x00\x00i\x00d\x00";
 
 // ---------- UTF-16: Zero in the middle (little-out)
-pub(crate) const UTF_16_FIXED_FORCE_ZERO_LITTLE_ZERO_IN_MIDDLE_OUT: &[u8; UTF_16_FIXED_LENGTH_DATA] =
-    b"v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
-pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_LITTLE_ZERO_IN_MIDDLE_OUT: &[u8; UTF_16_FIXED_LENGTH_DATA] =
-    b"v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+pub(crate) const UTF_16_FIXED_FORCE_ZERO_LITTLE_ZERO_IN_MIDDLE_OUT:
+    &[u8; UTF_16_FIXED_LENGTH_DATA] = b"v\x00a\x00\x00\x00\x00\x00\x00\x00";
+pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_LITTLE_ZERO_IN_MIDDLE_OUT:
+    &[u8; UTF_16_FIXED_LENGTH_DATA] = b"v\x00a\x00\x00\x00\x00\x00\x00\x00";
 
 // ---------- UTF-16: Zero in the middle (big-in)
-pub(crate) const UTF_16_FIXED_FORCE_ZERO_BIG_ZERO_IN_MIDDLE_IN: &[u8; UTF_16_FIXED_LENGTH_DATA] = b"\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00\x00\x00w\x00i\x00t\x00h\x00 \x00g\x00a\x00r\x00b\x00a\x00g\x00e";
-pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_BIG_ZERO_IN_MIDDLE_IN: &[u8; UTF_16_FIXED_LENGTH_DATA] = b"\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00\x00\x00w\x00i\x00t\x00h\x00 \x00g\x00a\x00r\x00b\x00a\x00g\x00e";
+pub(crate) const UTF_16_FIXED_FORCE_ZERO_BIG_ZERO_IN_MIDDLE_IN:
+    &[u8; UTF_16_FIXED_LENGTH_DATA] = b"\x00v\x00a\x00\x00\x00i\x00d";
+pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_BIG_ZERO_IN_MIDDLE_IN:
+    &[u8; UTF_16_FIXED_LENGTH_DATA] = b"\x00v\x00a\x00\x00\x00i\x00d";
 
 // ---------- UTF-16: Zero in the middle (big-out)
-pub(crate) const UTF_16_FIXED_FORCE_ZERO_BIG_ZERO_IN_MIDDLE_OUT: &[u8; UTF_16_FIXED_LENGTH_DATA] =
-    b"\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
-pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_BIG_ZERO_IN_MIDDLE_OUT: &[u8; UTF_16_FIXED_LENGTH_DATA] =
-    b"\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+pub(crate) const UTF_16_FIXED_FORCE_ZERO_BIG_ZERO_IN_MIDDLE_OUT:
+    &[u8; UTF_16_FIXED_LENGTH_DATA] = b"\x00v\x00a\x00\x00\x00\x00\x00\x00";
+pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_BIG_ZERO_IN_MIDDLE_OUT:
+    &[u8; UTF_16_FIXED_LENGTH_DATA] = b"\x00v\x00a\x00\x00\x00\x00\x00\x00";
 
 // ---------- UTF-32: Zero in the middle (little-in)
-pub(crate) const UTF_32_FIXED_FORCE_ZERO_LITTLE_ZERO_IN_MIDDLE_IN: &[u8; UTF_32_FIXED_LENGTH_DATA] = b"v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00\x00\x00\x00\x00\x00\x00w\x00\x00\x00i\x00\x00\x00t\x00\x00\x00h\x00\x00\x00 \x00\x00\x00g\x00\x00\x00a\x00\x00\x00r\x00\x00\x00b\x00\x00\x00a\x00\x00\x00g\x00\x00\x00e\x00";
-pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_LITTLE_ZERO_IN_MIDDLE_IN: &[u8; UTF_32_FIXED_LENGTH_DATA] = b"v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00\x00\x00\x00\x00\x00\x00w\x00\x00\x00i\x00\x00\x00t\x00\x00\x00h\x00\x00\x00 \x00\x00\x00g\x00\x00\x00a\x00\x00\x00r\x00\x00\x00b\x00\x00\x00a\x00\x00\x00g\x00\x00\x00e\x00";
+pub(crate) const UTF_32_FIXED_FORCE_ZERO_LITTLE_ZERO_IN_MIDDLE_IN:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"v\x00\x00\x00a\x00\x00\x00\x00\x00\x00\x00i\x00\x00\x00d\x00\x00\x00";
+pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_LITTLE_ZERO_IN_MIDDLE_IN:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"v\x00\x00\x00a\x00\x00\x00\x00\x00\x00\x00i\x00\x00\x00d\x00\x00\x00";
 
 // ---------- UTF-32: Zero in the middle (little-out)
-pub(crate) const UTF_32_FIXED_FORCE_ZERO_LITTLE_ZERO_IN_MIDDLE_OUT: &[u8; UTF_32_FIXED_LENGTH_DATA] =
-    b"v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
-pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_LITTLE_ZERO_IN_MIDDLE_OUT: &[u8; UTF_32_FIXED_LENGTH_DATA] =
-    b"v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+pub(crate) const UTF_32_FIXED_FORCE_ZERO_LITTLE_ZERO_IN_MIDDLE_OUT:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"v\x00\x00\x00a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_LITTLE_ZERO_IN_MIDDLE_OUT:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"v\x00\x00\x00a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 
 // ---------- UTF-32: Zero in the middle (big-in)
-pub(crate) const UTF_32_FIXED_FORCE_ZERO_BIG_ZERO_IN_MIDDLE_IN: &[u8; UTF_32_FIXED_LENGTH_DATA] = b"\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00\x00\x00\x00\x00w\x00\x00\x00i\x00\x00\x00t\x00\x00\x00h\x00\x00\x00 \x00\x00\x00g\x00\x00\x00a\x00\x00\x00r\x00\x00\x00b\x00\x00\x00a\x00\x00\x00g\x00\x00\x00e";
-pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_BIG_ZERO_IN_MIDDLE_IN: &[u8; UTF_32_FIXED_LENGTH_DATA] = b"\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00\x00\x00\x00\x00w\x00\x00\x00i\x00\x00\x00t\x00\x00\x00h\x00\x00\x00 \x00\x00\x00g\x00\x00\x00a\x00\x00\x00r\x00\x00\x00b\x00\x00\x00a\x00\x00\x00g\x00\x00\x00e";
+pub(crate) const UTF_32_FIXED_FORCE_ZERO_BIG_ZERO_IN_MIDDLE_IN:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"\x00\x00\x00v\x00\x00\x00a\x00\x00\x00\x00\x00\x00\x00i\x00\x00\x00d";
+pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_BIG_ZERO_IN_MIDDLE_IN:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"\x00\x00\x00v\x00\x00\x00a\x00\x00\x00\x00\x00\x00\x00i\x00\x00\x00d";
 
 // ---------- UTF-32: Zero in the middle (big-out)
-pub(crate) const UTF_32_FIXED_FORCE_ZERO_BIG_ZERO_IN_MIDDLE_OUT: &[u8; UTF_32_FIXED_LENGTH_DATA] =
-    b"\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
-pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_BIG_ZERO_IN_MIDDLE_OUT: &[u8; UTF_32_FIXED_LENGTH_DATA] =
-    b"\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+pub(crate) const UTF_32_FIXED_FORCE_ZERO_BIG_ZERO_IN_MIDDLE_OUT:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"\x00\x00\x00v\x00\x00\x00a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_BIG_ZERO_IN_MIDDLE_OUT:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"\x00\x00\x00v\x00\x00\x00a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 // ------------------------------------
 // ------ No Zero in the buffer -------
 // ------------------------------------
 
 // ---------- UTF-8: No zero in fixed buffer (str)
 // pub(crate) const FIXED_FORCE_ZERO_NO_ZERO_INSIDE_STR -- not allowed
-pub(crate) const FIXED_ALLOW_NO_ZERO_NO_ZERO_INSIDE_STR: &str =
-    "valid test case no zero";
+pub(crate) const FIXED_ALLOW_NO_ZERO_NO_ZERO_INSIDE_STR: &str = "valid";
 // pub(crate) const PREFIX_U8_NO_ZERO_INSIDE_STR -- same as "valid" case
 // pub(crate) const PREFIX_U16_NO_ZERO_INSIDE_STR -- same as "valid" case
 // pub(crate) const PREFIX_U32_NO_ZERO_INSIDE_STR -- same as "valid" case
@@ -255,23 +283,29 @@ pub(crate) const FIXED_ALLOW_NO_ZERO_NO_ZERO_INSIDE_STR: &str =
 
 // ---------- UTF-8: No zero in fixed buffer (little)
 pub(crate) const UTF_8_FIXED_ALLOW_NO_ZERO_LITTLE_NO_ZERO_INSIDE_IN:
-    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"valid test case no zero";
+    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"valid";
 
 // ---------- UTF-8: No zero in fixed buffer (big)
 pub(crate) const UTF_8_FIXED_ALLOW_NO_ZERO_BIG_NO_ZERO_INSIDE_IN:
-    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"valid test case no zero";
+    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"valid";
 
 // ---------- UTF-16: No zero in fixed buffer (little)
-pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_LITTLE_NO_ZERO_INSIDE_IN: &[u8; UTF_16_FIXED_LENGTH_DATA] = b"v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00 \x00n\x00o\x00 \x00z\x00e\x00r\x00o\x00";
+pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_LITTLE_NO_ZERO_INSIDE_IN:
+    &[u8; UTF_16_FIXED_LENGTH_DATA] = b"v\x00a\x00l\x00i\x00d\x00";
 
 // ---------- UTF-16: No zero in fixed buffer (big)
-pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_BIG_NO_ZERO_INSIDE_IN: &[u8; UTF_16_FIXED_LENGTH_DATA] = b"\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00 \x00n\x00o\x00 \x00z\x00e\x00r\x00o";
+pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_BIG_NO_ZERO_INSIDE_IN:
+    &[u8; UTF_16_FIXED_LENGTH_DATA] = b"\x00v\x00a\x00l\x00i\x00d";
 
 // ---------- UTF-32: No zero in fixed buffer (little)
-pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_LITTLE_NO_ZERO_INSIDE_IN: &[u8; UTF_32_FIXED_LENGTH_DATA] = b"v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e\x00\x00\x00 \x00\x00\x00n\x00\x00\x00o\x00\x00\x00 \x00\x00\x00z\x00\x00\x00e\x00\x00\x00r\x00\x00\x00o\x00\x00\x00";
+pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_LITTLE_NO_ZERO_INSIDE_IN:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00";
 
 // ---------- UTF-32: No zero in fixed buffer (big)
-pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_BIG_NO_ZERO_INSIDE_IN: &[u8; UTF_32_FIXED_LENGTH_DATA] = b"\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e\x00\x00\x00 \x00\x00\x00n\x00\x00\x00o\x00\x00\x00 \x00\x00\x00z\x00\x00\x00e\x00\x00\x00r\x00\x00\x00o";
+pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_BIG_NO_ZERO_INSIDE_IN:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d";
 
 // --------------------------------------
 // ------ 255 bytes in the buffer -------

--- a/tests/string/data/layouts.rs
+++ b/tests/string/data/layouts.rs
@@ -1,7 +1,7 @@
 use deku_string::{Size, StringLayout};
 
 /// How many bytes (for UTF-8) or u16 (for UTF-16) should be present in the buffer
-pub const FIXED_LENGTH: usize = 23;
+pub const FIXED_LENGTH: usize = 5;
 
 /// Layout for fixed string buffer with enforced zero byte presence
 pub const LAYOUT_FIXED_FORCE_ZERO: StringLayout = StringLayout::FixedLength {

--- a/tests/string/data/read_rejected.rs
+++ b/tests/string/data/read_rejected.rs
@@ -9,33 +9,33 @@ const UTF_32_FIXED_LENGTH_DATA: usize = FIXED_LENGTH * 4;
 // ---------- UTF encoding is invalid
 // error: parse
 pub(crate) const UTF_8_FIXED_FORCE_ZERO_LITTLE_INVALID_UTF:
-    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"invalid test case  \xe2\x28\xa1\x00";
+    &[u8; UTF_8_FIXED_LENGTH_DATA] = b" \xe2\x28\xa1\x00";
 pub(crate) const UTF_8_FIXED_ALLOW_NO_ZERO_LITTLE_INVALID_UTF:
-    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"invalid test case  \xe2\x28\xa1\x00";
+    &[u8; UTF_8_FIXED_LENGTH_DATA] = b" \xe2\x28\xa1\x00";
 pub(crate) const UTF_8_PREFIX_U8_LITTLE_INVALID_UTF: &[u8; 8] = b"\x07utf-\xe2\x28\xa1";
 pub(crate) const UTF_8_PREFIX_U16_LITTLE_INVALID_UTF: &[u8; 9] =
     b"\x07\x00utf-\xe2\x28\xa1";
 pub(crate) const UTF_8_PREFIX_U32_LITTLE_INVALID_UTF: &[u8; 11] =
     b"\x07\x00\x00\x00utf-\xe2\x28\xa1";
 pub(crate) const UTF_8_ZERO_ENDED_LITTLE_INVALID_UTF: &[u8; UTF_8_FIXED_LENGTH_DATA] =
-    b"invalid test case  \xe2\x28\xa1\x00";
+    b" \xe2\x28\xa1\x00";
 
 pub(crate) const UTF_8_FIXED_FORCE_ZERO_BIG_INVALID_UTF: &[u8;
-     UTF_8_FIXED_LENGTH_DATA] = b"invalid test case  \xe2\x28\xa1\x00";
+     UTF_8_FIXED_LENGTH_DATA] = b" \xe2\x28\xa1\x00";
 pub(crate) const UTF_8_FIXED_ALLOW_NO_ZERO_BIG_INVALID_UTF:
-    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"invalid test case  \xe2\x28\xa1\x00";
+    &[u8; UTF_8_FIXED_LENGTH_DATA] = b" \xe2\x28\xa1\x00";
 pub(crate) const UTF_8_PREFIX_U8_BIG_INVALID_UTF: &[u8; 8] = b"\x07utf-\xe2\x28\xa1";
 pub(crate) const UTF_8_PREFIX_U16_BIG_INVALID_UTF: &[u8; 9] =
     b"\x00\x07utf-\xe2\x28\xa1";
 pub(crate) const UTF_8_PREFIX_U32_BIG_INVALID_UTF: &[u8; 11] =
     b"\x00\x00\x00\x07utf-\xe2\x28\xa1";
 pub(crate) const UTF_8_ZERO_ENDED_BIG_INVALID_UTF: &[u8; UTF_8_FIXED_LENGTH_DATA] =
-    b"invalid test case  \xe2\x28\xa1\x00";
+    b" \xe2\x28\xa1\x00";
 
 // ---------- No zero while expected
 // error: assertion
 pub(crate) const UTF_8_FIXED_FORCE_ZERO_LITTLE_NO_ZERO_INSIDE:
-    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"invalid test case zero?";
+    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"zero?";
 // pub(crate) const FIXED_ALLOW_NO_ZERO_LITTLE_NO_ZERO_INSIDE — is accepted
 // pub(crate) const PREFIX_U8_LITTLE_NO_ZERO_INSIDE: &[u8; 3] — is accepted
 // pub(crate) const PREFIX_U16_LITTLE_NO_ZERO_INSIDE: &[u8; 4] — is accepted
@@ -43,7 +43,7 @@ pub(crate) const UTF_8_FIXED_FORCE_ZERO_LITTLE_NO_ZERO_INSIDE:
 // pub(crate) const ZERO_ENDED_LITTLE_NO_ZERO_INSIDE — is required
 
 pub(crate) const UTF_8_FIXED_FORCE_ZERO_BIG_NO_ZERO_INSIDE:
-    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"invalid test case zero?";
+    &[u8; UTF_8_FIXED_LENGTH_DATA] = b"zero?";
 // pub(crate) const FIXED_ALLOW_NO_ZERO_BIG_NO_ZERO_INSIDE — is accepted
 // pub(crate) const PREFIX_U8_BIG_NO_ZERO_INSIDE: &[u8; 3] — is accepted
 // pub(crate) const PREFIX_U16_BIG_NO_ZERO_INSIDE: &[u8; 4] — is accepted
@@ -123,44 +123,51 @@ pub(crate) const UTF_8_ZERO_ENDED_BIG_SMALL_BUFFER: &[u8; 0] = &[];
 // pub(crate) const PREFIX_U8_LITTLE_NO_ZERO_INSIDE: &[u8; 1] — length is specified in format
 // pub(crate) const PREFIX_U16_LITTLE_NO_ZERO_INSIDE: &[u8; 2] — length is specified in format
 // pub(crate) const PREFIX_U32_LITTLE_NO_ZERO_INSIDE: &[u8; 4] — length is specified in format
-pub(crate) const UTF_8_ZERO_ENDED_LITTLE_NO_ZERO_INSIDE: &[u8; 17] =
-    b"invalid test case";
+pub(crate) const UTF_8_ZERO_ENDED_LITTLE_NO_ZERO_INSIDE: &[u8; 7] = b"no zero";
 
 // pub(crate) const FIXED_FORCE_ZERO_BIG_NO_ZERO_INSIDE — length is specified in format
 // pub(crate) const FIXED_ALLOW_NO_ZERO_BIG_NO_ZERO_INSIDE — length is specified in format
 // pub(crate) const PREFIX_U8_BIG_NO_ZERO_INSIDE: &[u8; 1] — length is specified in format
 // pub(crate) const PREFIX_U16_BIG_NO_ZERO_INSIDE: &[u8; 2] — length is specified in format
 // pub(crate) const PREFIX_U32_BIG_NO_ZERO_INSIDE: &[u8; 4] — length is specified in format
-pub(crate) const UTF_8_ZERO_ENDED_BIG_NO_ZERO_INSIDE: &[u8; 17] = b"invalid test case";
+pub(crate) const UTF_8_ZERO_ENDED_BIG_NO_ZERO_INSIDE: &[u8; 7] = b"no zero";
 
 // ---------- UTF encoding is invalid
 // error: parse
-pub(crate) const UTF_16_FIXED_FORCE_ZERO_LITTLE_INVALID_UTF: &[u8; UTF_16_FIXED_LENGTH_DATA] = b"i\x00n\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00 \x00 \x00\xdc\xdc\xdc\xdc\xdc\xdc\x00\x00";
-pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_LITTLE_INVALID_UTF: &[u8; UTF_16_FIXED_LENGTH_DATA] = b"i\x00n\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00 \x00 \x00\xdc\xdc\xdc\xdc\xdc\xdc\x00\x00";
+pub(crate) const UTF_16_FIXED_FORCE_ZERO_LITTLE_INVALID_UTF:
+    &[u8; UTF_16_FIXED_LENGTH_DATA] = b" \x00\xdc\xdc\xdc\xdc\xdc\xdc\x00\x00";
+pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_LITTLE_INVALID_UTF:
+    &[u8; UTF_16_FIXED_LENGTH_DATA] = b" \x00\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc";
 pub(crate) const UTF_16_PREFIX_U8_LITTLE_INVALID_UTF: &[u8; 3] = b"\x01\xdc\xdc";
 pub(crate) const UTF_16_PREFIX_U16_LITTLE_INVALID_UTF: &[u8; 4] = b"\x01\x00\xdc\xdc";
 pub(crate) const UTF_16_PREFIX_U32_LITTLE_INVALID_UTF: &[u8; 6] =
     b"\x01\x00\x00\x00\xdc\xdc";
-pub(crate) const UTF_16_ZERO_ENDED_LITTLE_INVALID_UTF: &[u8; UTF_16_FIXED_LENGTH_DATA] = b"i\x00n\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00 \x00 \x00\xdc\xdc\xdc\xdc\xdc\xdc\x00\x00";
+pub(crate) const UTF_16_ZERO_ENDED_LITTLE_INVALID_UTF: &[u8; UTF_16_FIXED_LENGTH_DATA] =
+    b"\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\x00\x00";
 
-pub(crate) const UTF_16_FIXED_FORCE_ZERO_BIG_INVALID_UTF: &[u8; UTF_16_FIXED_LENGTH_DATA] = b"\x00i\x00n\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00 \x00 \xdc\xdc\xdc\xdc\xdc\xdc\x00\x00";
-pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_BIG_INVALID_UTF: &[u8; UTF_16_FIXED_LENGTH_DATA] = b"\x00i\x00n\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00 \x00 \xdc\xdc\xdc\xdc\xdc\xdc\x00\x00";
+pub(crate) const UTF_16_FIXED_FORCE_ZERO_BIG_INVALID_UTF:
+    &[u8; UTF_16_FIXED_LENGTH_DATA] = b"\x00 \xdc\xdc\xdc\xdc\xdc\xdc\x00\x00";
+pub(crate) const UTF_16_FIXED_ALLOW_NO_ZERO_BIG_INVALID_UTF:
+    &[u8; UTF_16_FIXED_LENGTH_DATA] = b"\x00 \xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc";
 pub(crate) const UTF_16_PREFIX_U8_BIG_INVALID_UTF: &[u8; 3] = b"\x01\xdc\xdc";
 pub(crate) const UTF_16_PREFIX_U16_BIG_INVALID_UTF: &[u8; 4] = b"\x00\x01\xdc\xdc";
 pub(crate) const UTF_16_PREFIX_U32_BIG_INVALID_UTF: &[u8; 6] =
     b"\x00\x00\x00\x01\xdc\xdc";
-pub(crate) const UTF_16_ZERO_ENDED_BIG_INVALID_UTF: &[u8; UTF_16_FIXED_LENGTH_DATA] = b"\x00i\x00n\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00 \x00 \xdc\xdc\xdc\xdc\xdc\xdc\x00\x00";
+pub(crate) const UTF_16_ZERO_ENDED_BIG_INVALID_UTF: &[u8; UTF_16_FIXED_LENGTH_DATA] =
+    b"\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\x00\x00";
 
 // ---------- No zero while expected
 // error: assertion
-pub(crate) const UTF_16_FIXED_FORCE_ZERO_LITTLE_NO_ZERO_INSIDE: &[u8; UTF_16_FIXED_LENGTH_DATA] = b"v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00 \x00n\x00o\x00 \x00z\x00e\x00r\x00o\x00";
+pub(crate) const UTF_16_FIXED_FORCE_ZERO_LITTLE_NO_ZERO_INSIDE:
+    &[u8; UTF_16_FIXED_LENGTH_DATA] = b"z\x00e\x00r\x00o\x00?\x00";
 // pub(crate) const FIXED_ALLOW_NO_ZERO_LITTLE_NO_ZERO_INSIDE — is accepted
 // pub(crate) const PREFIX_U8_LITTLE_NO_ZERO_INSIDE: &[u8; 3] — is accepted
 // pub(crate) const PREFIX_U16_LITTLE_NO_ZERO_INSIDE: &[u8; 4] — is accepted
 // pub(crate) const PREFIX_U32_LITTLE_NO_ZERO_INSIDE: &[u8; 6] — is accepted
 // pub(crate) const ZERO_ENDED_LITTLE_NO_ZERO_INSIDE — is required
 
-pub(crate) const UTF_16_FIXED_FORCE_ZERO_BIG_NO_ZERO_INSIDE: &[u8; UTF_16_FIXED_LENGTH_DATA] = b"\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00 \x00n\x00o\x00 \x00z\x00e\x00r\x00o";
+pub(crate) const UTF_16_FIXED_FORCE_ZERO_BIG_NO_ZERO_INSIDE:
+    &[u8; UTF_16_FIXED_LENGTH_DATA] = b"\x00z\x00e\x00r\x00o\x00?";
 // pub(crate) const FIXED_ALLOW_NO_ZERO_BIG_NO_ZERO_INSIDE — is accepted
 // pub(crate) const PREFIX_U8_BIG_NO_ZERO_INSIDE: &[u8; 3] — is accepted
 // pub(crate) const PREFIX_U16_BIG_NO_ZERO_INSIDE: &[u8; 4] — is accepted
@@ -245,48 +252,62 @@ pub(crate) const UTF_16_ZERO_ENDED_BIG_SMALL_BUFFER: &[u8; 0] = &[];
 // pub(crate) const PREFIX_U8_LITTLE_NO_ZERO_INSIDE: &[u8; 1] — length is specified in format
 // pub(crate) const PREFIX_U16_LITTLE_NO_ZERO_INSIDE: &[u8; 2] — length is specified in format
 // pub(crate) const PREFIX_U32_LITTLE_NO_ZERO_INSIDE: &[u8; 4] — length is specified in format
-pub(crate) const UTF_16_ZERO_ENDED_LITTLE_NO_ZERO_INSIDE: &[u8; 34] =
-    b"i\x00n\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00";
+pub(crate) const UTF_16_ZERO_ENDED_LITTLE_NO_ZERO_INSIDE: &[u8; 10] =
+    b"z\x00e\x00r\x00o\x00?\x00";
 
 // pub(crate) const FIXED_FORCE_ZERO_BIG_NO_ZERO_INSIDE — length is specified in format
 // pub(crate) const FIXED_ALLOW_NO_ZERO_BIG_NO_ZERO_INSIDE — length is specified in format
 // pub(crate) const PREFIX_U8_BIG_NO_ZERO_INSIDE: &[u8; 1] — length is specified in format
 // pub(crate) const PREFIX_U16_BIG_NO_ZERO_INSIDE: &[u8; 2] — length is specified in format
 // pub(crate) const PREFIX_U32_BIG_NO_ZERO_INSIDE: &[u8; 4] — length is specified in format
-pub(crate) const UTF_16_ZERO_ENDED_BIG_NO_ZERO_INSIDE: &[u8; 34] =
-    b"\x00i\x00n\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e";
+pub(crate) const UTF_16_ZERO_ENDED_BIG_NO_ZERO_INSIDE: &[u8; 10] =
+    b"\x00z\x00e\x00r\x00o\x00?";
 
 // ---------- UTF encoding is invalid
 // error: parse
-pub(crate) const UTF_32_FIXED_FORCE_ZERO_LITTLE_INVALID_UTF: &[u8; UTF_32_FIXED_LENGTH_DATA] = b"i\x00\x00\x00n\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e\x00\x00\x00 \x00\x00\x00 \x00\x00\x00\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\x00\x00\x00\x00\x00\x00";
-pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_LITTLE_INVALID_UTF: &[u8; UTF_32_FIXED_LENGTH_DATA] = b"i\x00\x00\x00n\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e\x00\x00\x00 \x00\x00\x00 \x00\x00\x00\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\x00\x00\x00\x00\x00\x00";
+pub(crate) const UTF_32_FIXED_FORCE_ZERO_LITTLE_INVALID_UTF:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b" \x00\x00\x00\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\x00\x00\x00\x00";
+pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_LITTLE_INVALID_UTF:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b" \x00\x00\x00\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc";
 pub(crate) const UTF_32_PREFIX_U8_LITTLE_INVALID_UTF: &[u8; 5] =
     b"\x01\xdc\xdc\xdc\xdc";
 pub(crate) const UTF_32_PREFIX_U16_LITTLE_INVALID_UTF: &[u8; 6] =
     b"\x01\x00\xdc\xdc\xdc\xdc";
 pub(crate) const UTF_32_PREFIX_U32_LITTLE_INVALID_UTF: &[u8; 8] =
     b"\x01\x00\x00\x00\xdc\xdc\xdc\xdc";
-pub(crate) const UTF_32_ZERO_ENDED_LITTLE_INVALID_UTF: &[u8; UTF_32_FIXED_LENGTH_DATA] = b"i\x00\x00\x00n\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e\x00\x00\x00 \x00\x00\x00\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\x00\x00\x00\x00\x00\x00";
+pub(crate) const UTF_32_ZERO_ENDED_LITTLE_INVALID_UTF: &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\x00\x00\x00\x00\x00";
 
-pub(crate) const UTF_32_FIXED_FORCE_ZERO_BIG_INVALID_UTF: &[u8; UTF_32_FIXED_LENGTH_DATA] = b"\x00\x00\x00i\x00\x00\x00n\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e\x00\x00\x00 \xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\x00\x00\x00\x00\x00\x00";
-pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_BIG_INVALID_UTF: &[u8; UTF_32_FIXED_LENGTH_DATA] = b"\x00\x00\x00i\x00\x00\x00n\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e\x00\x00\x00 \xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\x00\x00\x00\x00\x00\x00";
+pub(crate) const UTF_32_FIXED_FORCE_ZERO_BIG_INVALID_UTF:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"\x00\x00\x00 \xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\x00\x00\x00\x00";
+pub(crate) const UTF_32_FIXED_ALLOW_NO_ZERO_BIG_INVALID_UTF:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"\x00\x00\x00 \xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc";
 pub(crate) const UTF_32_PREFIX_U8_BIG_INVALID_UTF: &[u8; 5] = b"\x01\xdc\xdc\xdc\xdc";
 pub(crate) const UTF_32_PREFIX_U16_BIG_INVALID_UTF: &[u8; 6] =
     b"\x00\x01\xdc\xdc\xdc\xdc";
 pub(crate) const UTF_32_PREFIX_U32_BIG_INVALID_UTF: &[u8; 8] =
     b"\x00\x00\x00\x01\xdc\xdc\xdc\xdc";
-pub(crate) const UTF_32_ZERO_ENDED_BIG_INVALID_UTF: &[u8; UTF_32_FIXED_LENGTH_DATA] = b"\x00\x00\x00i\x00\x00\x00n\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e\x00\x00\x00 \xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\x00\x00\x00\x00\x00\x00";
+pub(crate) const UTF_32_ZERO_ENDED_BIG_INVALID_UTF: &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\xdc\x00\x00\x00\x00\x00";
 
 // ---------- No zero while expected
 // error: assertion
-pub(crate) const UTF_32_FIXED_FORCE_ZERO_LITTLE_NO_ZERO_INSIDE: &[u8; UTF_32_FIXED_LENGTH_DATA] = b"v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e\x00\x00\x00 \x00\x00\x00n\x00\x00\x00o\x00\x00\x00 \x00\x00\x00z\x00\x00\x00e\x00\x00\x00r\x00\x00\x00o\x00\x00\x00";
+pub(crate) const UTF_32_FIXED_FORCE_ZERO_LITTLE_NO_ZERO_INSIDE:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"z\x00\x00\x00e\x00\x00\x00r\x00\x00\x00o\x00\x00\x00?\x00\x00\x00";
 // pub(crate) const FIXED_ALLOW_NO_ZERO_LITTLE_NO_ZERO_INSIDE — is accepted
 // pub(crate) const PREFIX_U8_LITTLE_NO_ZERO_INSIDE: &[u8; 3] — is accepted
 // pub(crate) const PREFIX_U16_LITTLE_NO_ZERO_INSIDE: &[u8; 4] — is accepted
 // pub(crate) const PREFIX_U32_LITTLE_NO_ZERO_INSIDE: &[u8; 6] — is accepted
 // pub(crate) const ZERO_ENDED_LITTLE_NO_ZERO_INSIDE — is required
 
-pub(crate) const UTF_32_FIXED_FORCE_ZERO_BIG_NO_ZERO_INSIDE: &[u8; UTF_32_FIXED_LENGTH_DATA] = b"\x00\x00\x00v\x00\x00\x00a\x00\x00\x00l\x00\x00\x00i\x00\x00\x00d\x00\x00\x00 \x00\x00\x00t\x00\x00\x00e\x00\x00\x00s\x00\x00\x00t\x00\x00\x00 \x00\x00\x00c\x00\x00\x00a\x00\x00\x00s\x00\x00\x00e\x00\x00\x00 \x00\x00\x00n\x00\x00\x00o\x00\x00\x00 \x00\x00\x00z\x00\x00\x00e\x00\x00\x00r\x00\x00\x00o";
+pub(crate) const UTF_32_FIXED_FORCE_ZERO_BIG_NO_ZERO_INSIDE:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"\x00\x00\x00z\x00\x00\x00e\x00\x00\x00r\x00\x00\x00o\x00\x00\x00?";
 // pub(crate) const FIXED_ALLOW_NO_ZERO_BIG_NO_ZERO_INSIDE — is accepted
 // pub(crate) const PREFIX_U8_BIG_NO_ZERO_INSIDE: &[u8; 3] — is accepted
 // pub(crate) const PREFIX_U16_BIG_NO_ZERO_INSIDE: &[u8; 4] — is accepted
@@ -374,13 +395,14 @@ pub(crate) const UTF_32_ZERO_ENDED_BIG_SMALL_BUFFER: &[u8; 0] = &[];
 // pub(crate) const PREFIX_U8_LITTLE_NO_ZERO_INSIDE: &[u8; 1] — length is specified in format
 // pub(crate) const PREFIX_U16_LITTLE_NO_ZERO_INSIDE: &[u8; 2] — length is specified in format
 // pub(crate) const PREFIX_U32_LITTLE_NO_ZERO_INSIDE: &[u8; 4] — length is specified in format
-pub(crate) const UTF_32_ZERO_ENDED_LITTLE_NO_ZERO_INSIDE: &[u8; 34] =
-    b"i\x00n\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e\x00";
+pub(crate) const UTF_32_ZERO_ENDED_LITTLE_NO_ZERO_INSIDE:
+    &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"z\x00\x00\x00e\x00\x00\x00r\x00\x00\x00o\x00\x00\x00?\x00\x00\x00";
 
 // pub(crate) const FIXED_FORCE_ZERO_BIG_NO_ZERO_INSIDE — length is specified in format
 // pub(crate) const FIXED_ALLOW_NO_ZERO_BIG_NO_ZERO_INSIDE — length is specified in format
 // pub(crate) const PREFIX_U8_BIG_NO_ZERO_INSIDE: &[u8; 1] — length is specified in format
 // pub(crate) const PREFIX_U16_BIG_NO_ZERO_INSIDE: &[u8; 2] — length is specified in format
 // pub(crate) const PREFIX_U32_BIG_NO_ZERO_INSIDE: &[u8; 4] — length is specified in format
-pub(crate) const UTF_32_ZERO_ENDED_BIG_NO_ZERO_INSIDE: &[u8; 34] =
-    b"\x00i\x00n\x00v\x00a\x00l\x00i\x00d\x00 \x00t\x00e\x00s\x00t\x00 \x00c\x00a\x00s\x00e";
+pub(crate) const UTF_32_ZERO_ENDED_BIG_NO_ZERO_INSIDE: &[u8; UTF_32_FIXED_LENGTH_DATA] =
+    b"\x00\x00\x00z\x00\x00\x00e\x00\x00\x00r\x00\x00\x00o\x00\x00\x00?";

--- a/tests/string/data/write_rejected.rs
+++ b/tests/string/data/write_rejected.rs
@@ -5,7 +5,7 @@ pub const ASSERTION_ZERO_INSIDE_STR: &str = "invalid test\x00with garbage";
 /// A 65536 bytes long string to test out-of-bound checks on write.
 pub const ASSERTION_TOO_BIG_DATA: &str = include_str!("../../64k_data");
 
-pub const IO_DATA: &str = "valid test case w zero";
+pub const IO_DATA: &str = "text";
 
 pub const IO_FIXED_FORCE_ZERO_DATA_SIZE: u64 = 0;
 pub const IO_FIXED_ALLOW_NO_ZERO_DATA_SIZE: u64 = 0;
@@ -14,10 +14,10 @@ pub const IO_PREFIX_U16_DATA_SIZE: u64 = 4;
 pub const IO_PREFIX_U32_DATA_SIZE: u64 = 5;
 pub const IO_ZERO_ENDED_DATA_SIZE: u64 = 0;
 
-pub const IO_FIXED_END: &str = "valid";
+pub const IO_FIXED_END: &str = "text";
 
-pub const IO_FIXED_FORCE_ZERO_FIXED_END_SIZE: u64 = 10;
-pub const IO_FIXED_ALLOW_NO_ZERO_FIXED_END_SIZE: u64 = 10;
+pub const IO_FIXED_FORCE_ZERO_FIXED_END_SIZE: u64 = 4;
+pub const IO_FIXED_ALLOW_NO_ZERO_FIXED_END_SIZE: u64 = 4;
 
 pub const IO_PREFIX: &str = "value";
 


### PR DESCRIPTION
UTF-16 is twice as long.
UTF-32 is four times as long.